### PR TITLE
Update URL of xerces source zip

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -21,7 +21,7 @@ class xercescConan(ConanFile):
 	src_dir = "xerces-c-3.1.4"
 
 	def source(self):
-		tools.download("http://ftp.halifax.rwth-aachen.de/apache/xerces/c/3/sources/xerces-c-3.1.4.zip", "xerces.zip")
+		tools.download("https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-3.1.4.zip", "xerces.zip")
 		zip_ref = zipfile.ZipFile("xerces.zip", 'r')
 		zip_ref.extractall()
 		zip_ref.close()

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,86 +1,55 @@
-from conans import ConanFile, tools, AutoToolsBuildEnvironment
+from conans import ConanFile, tools, CMake
 import zipfile
-import os
 
 class xercescConan(ConanFile):
-	name = "xerces-c"
-	version = "3.1.4"
-	license = "http://www.apache.org/licenses/LICENSE-2.0.html"
-	settings = {
-		"os": ["Windows", "Linux"],
-		"compiler": ["Visual Studio", "gcc"],
-		"build_type": ["Debug", "Release"],
-		"arch": ["x86", "x86_64"]
-	}
-	url = "https://github.com/Brunni/conan-xerces-c"
-	options = {
+    name = "xerces-c"
+    version = "3.2.0"
+    license = "http://www.apache.org/licenses/LICENSE-2.0.html"
+    settings = {
+        "os": ["Windows", "Linux"],
+        "compiler": ["Visual Studio", "gcc"],
+        "build_type": ["Debug", "Release"],
+        "arch": ["x86", "x86_64"]
+    }
+    url = "https://github.com/stefan-titus-keysight/conan-xerces-c"
+    options = {
         "with_icu": [True, False],
-		"shared": [True, False]
-	}
-	default_options = "with_icu=False","shared=True"
-	src_dir = "xerces-c-3.1.4"
+        "shared": [True, False]
+    }
+    default_options = "with_icu=False","shared=True"
+    src_dir = "xerces-c-3.2.0"
 
-	def source(self):
-		tools.download("https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-3.1.4.zip", "xerces.zip")
-		zip_ref = zipfile.ZipFile("xerces.zip", 'r')
-		zip_ref.extractall()
-		zip_ref.close()
-	
-	def build(self):
-		if self.settings.compiler == "Visual Studio":
-			self.build_with_vs()
-		else:
-			self.build_with_make()
+    def source(self):
+        tools.download("https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-3.2.0.zip", "xerces.zip")
+        zip_ref = zipfile.ZipFile("xerces.zip", 'r')
+        zip_ref.extractall()
+        zip_ref.close()
+    
+    def build(self):
+        self.cmake = CMake(self)
+        self.cmake.configure(source_dir=self.conanfile_directory + "/" + self.src_dir, build_dir="./build/")
+        self.cmake.build()
 
-	def package(self):
-		self.copy("*.hpp", dst="include", src="%s/src" % self.src_dir)
-		self.copy("*.c", dst="include", src="%s/src" % self.src_dir)
-		self.copy("*.lib", dst="lib", keep_path=False)
-		self.copy("*.exp", dst="lib", keep_path=False)
-		self.copy("*.dll", dst="bin", keep_path=False)
-		self.copy("*.a", dst="lib", keep_path=False)
-		self.copy("*.so", dst="lib", keep_path=False)
-		
-	def build_with_vs(self):
-		solution_path = "{0}/{1}/projects/Win32/VC{2}/xerces-all/xerces-all.sln".format(self.conanfile_directory, self.src_dir, str(self.settings.compiler.version))
-#		solution_path = os.path.join(os.path.dirname(__file__), solution_path)
-		config_name = str(self.settings.build_type)	 # *TODO: other options 
-		platform = "x64" if self.settings.arch == "x86_64" else "Win32"
-		config_name = "Static %s" % str(self.settings.build_type) if self.options.shared == False else str(self.settings.build_type)
-		config_name = "ICU %s" % str(self.settings.build_type) if self.options.with_icu == True else config_name
-		vs_version = self.settings.compiler.version
+    def package(self):
+        # This is to get util/Xerces_autoconf_config.hpp
+        self.copy("*.hpp", dst="include", src="%s/src" % self.cmake.build_dir)
 
-		build_cmd = "msbuild \"{solution}\" \"/p:Configuration={config}\" \"/p:Platform={platform}\" \"/target:XercesLib\" \"/p:VisualStudioVersion={vs_version}\" /p:OutputPath={output_path} /p:OutDir={output_path} /m".format(
-			solution=solution_path,
-			config=config_name,
-			platform=platform,
-			vs_version=vs_version,
-			output_path="%s/build" % self.conanfile_directory # shorter output path because of windows path length issue
-		)
-#		print (build_cmd)
-		self.run(build_cmd)
-
-	# *WARNING: untested!
-	def build_with_make(self):
-		if self.options.shared == True:
-			sharedoption = "--disable-static"
-		else:
-			sharedoption = "--disable-shared"
-		env_build = AutoToolsBuildEnvironment(self)
-		self.run("cd %s && %s" % (self.src_dir, 'chmod u+x configure'))
-		self.run("cd %s/config && %s" % (self.src_dir, 'chmod u+x pretty-make'))
-	        with tools.environment_append(env_build.vars):
-			self.run("cd %s && %s %s" % (self.src_dir, './configure', sharedoption))
-			self.run("cd %s && %s " % (self.src_dir, 'make -j 8'))
-		
-	def package_info(self):
-		if self.settings.os == "Linux":
-			self.cpp_info.libs = ["xerces-c", "pthread"]
-		else:
-			if self.options.shared == True:
-				if self.settings.build_type == "Debug":
-					self.cpp_info.libs = ["xerces-c_3D"]
-				else:
-					self.cpp_info.libs = ["xerces-c_3"]
-			else:
-				self.cpp_info.libs = ["xerces-c_static_3"]
+        self.copy("*.hpp", dst="include", src="%s/src" % self.src_dir)
+        self.copy("*.c", dst="include", src="%s/src" % self.src_dir)
+        self.copy("*.lib", dst="lib", keep_path=False)
+        self.copy("*.exp", dst="lib", keep_path=False)
+        self.copy("*.dll", dst="bin", keep_path=False)
+        self.copy("*.a", dst="lib", keep_path=False)
+        self.copy("*.so", dst="lib", keep_path=False)
+        
+    def package_info(self):
+        if self.settings.os == "Linux":
+            self.cpp_info.libs = ["xerces-c", "pthread"]
+        else:
+            if self.options.shared == True:
+                if self.settings.build_type == "Debug":
+                    self.cpp_info.libs = ["xerces-c_3D"]
+                else:
+                    self.cpp_info.libs = ["xerces-c_3"]
+            else:
+                self.cpp_info.libs = ["xerces-c_static_3"]

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -2,7 +2,7 @@ from conans import ConanFile, CMake
 import os
 
 channel = os.getenv("CONAN_CHANNEL", "testing")
-username = os.getenv("CONAN_USERNAME", "Brunni")
+username = os.getenv("CONAN_USERNAME", "stefan-titus-keysight")
 
 
 class ReuseConan(ConanFile):
@@ -12,17 +12,17 @@ class ReuseConan(ConanFile):
         "build_type": ["Debug", "Release"],
         "arch": ["x86", "x86_64"]
     }
-    requires = "xerces-c/3.1.4@%s/%s" % (username, channel)
+    requires = "xerces-c/3.2.0@%s/%s" % (username, channel)
     generators = "cmake"
 
     def build(self):
-        cmake = CMake(self.settings)
-        self.run('cmake "%s" %s' % (self.conanfile_directory, cmake.command_line))
-        self.run("cmake --build . %s" % cmake.build_config)
+        cmake = CMake(self)
+        cmake.configure(source_dir=self.conanfile_directory)
+        cmake.build()
 
     def test(self):
         self.run(os.sep.join([".","bin","test"]))
-		
-	def imports(self):
-		self.copy("*.dll", "bin", "bin")
-		self.copy("*.dylib", "bin", "bin")
+        
+    def imports(self):
+        self.copy("*.dll", "bin", "bin")
+        self.copy("*.dylib", "bin", "bin")


### PR DESCRIPTION
With the release of 3.2.0, the old location of the source zip file no longer contains 3.1.4. This update changes the URL to a more permanent location.